### PR TITLE
feat(components): update flisol dates and editions

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -75,14 +75,14 @@
               ></path><path d="M16 18h.01"></path></svg
             >
           </div>
-          26 de abril del 2025
+          27 de abril del 2026
         </dt>
         <dd
           class="mt-1 flex flex-auto flex-col text-base leading-7 text-gray-300"
         >
           <p class="flex-auto">
             El Flisol se lleva a cabo anualmente el cuarto sábado de abril, por
-            lo que este año lo celebraremos el 26 de abril.
+            lo que este año lo celebraremos el 27 de abril.
           </p>
         </dd>
       </div>

--- a/src/components/Editions.astro
+++ b/src/components/Editions.astro
@@ -1,10 +1,15 @@
 ---
 const editions = [
   {
+    title: "Flisol Cuba 2025",
+    date: "26 de abril del 2025",
+    youtube: "https://www.youtube.com/embed/fGJrYY9JM9Y?si=83hHtKNFC-RMO4Px",
+  },
+  {
     title: "Flisol Cuba 2024",
     date: "27 de abril del 2024",
     youtube: "https://www.youtube.com/embed/rrQophvXDEo?si=jTJwxBtkRP3uFKHt",
-  },
+  }
 ];
 ---
 


### PR DESCRIPTION
- Adjust About component to announce the 27 April 2026 event date
- Keep annual scheduling note aligned with fourth Saturday messaging
- Add 2025 edition entry with archived stream link to the Editions list
- Ensure visitors see up-to-date event timeline and supporting resources